### PR TITLE
fix missing parenthesis for print for Python 3 compatiblity

### DIFF
--- a/rotary_encoder.py
+++ b/rotary_encoder.py
@@ -21,7 +21,7 @@ try:
                                 counter += 1
                         else:
                                 counter -= 1
-                        print counter
+                        print(counter)
                 clkLastState = clkState
                 sleep(0.01)
 finally:


### PR DESCRIPTION
In Python 3 print statements are replaced with print functions that require parenthesis.
Without those parenthesis the code won't execute in Python 3.
This code is still Python 2 compatible.